### PR TITLE
delete setlists with editedFromIds on setlists page

### DIFF
--- a/app/models/setlist.server.ts
+++ b/app/models/setlist.server.ts
@@ -120,6 +120,12 @@ export async function deleteSetlist(setlistId: Setlist['id']) {
   })
 }
 
+export async function deleteManySetlists(ids: Setlist['id'][]) {
+  return await prisma.setlist.deleteMany({
+    where: { id: { in: ids } }
+  })
+}
+
 export async function createSetlistAuto(bandId: Band['id'], settings: SetlistSettings) {
   const { filters, setCount, setLength } = settings
   const { noBallads, noCovers, onlyCovers } = filters

--- a/app/models/setlist.server.ts
+++ b/app/models/setlist.server.ts
@@ -126,6 +126,19 @@ export async function deleteManySetlists(ids: Setlist['id'][]) {
   })
 }
 
+export async function deleteUnneededClonedSetlists(bandId: Setlist['bandId']) {
+  // get all setlists of a band
+  const setlists = await prisma.setlist.findMany({
+    where: { bandId },
+    select: { id: true, editedFromId: true }
+  })
+  // filter to only setlists with an editedFromId
+  const clonedSetlists = setlists.filter(setlist => !!setlist.editedFromId)
+  if (!clonedSetlists.length) return
+  // delete all those setlists
+  return await deleteManySetlists(clonedSetlists.map(setlist => setlist.id))
+}
+
 export async function createSetlistAuto(bandId: Band['id'], settings: SetlistSettings) {
   const { filters, setCount, setLength } = settings
   const { noBallads, noCovers, onlyCovers } = filters

--- a/app/routes/$bandId/setlist/$setlistId.tsx
+++ b/app/routes/$bandId/setlist/$setlistId.tsx
@@ -1,7 +1,7 @@
 import type { LoaderArgs, MetaFunction } from "@remix-run/server-runtime";
 import { json } from '@remix-run/node'
 import invariant from "tiny-invariant";
-import { getSetlist } from "~/models/setlist.server";
+import { deleteUnneededClonedSetlists, getSetlist } from "~/models/setlist.server";
 import { requireUserId } from "~/session.server";
 import { Outlet, useLoaderData, useLocation, useNavigate, useParams } from "@remix-run/react";
 import { AvatarTitle, Breadcrumbs, Button, CatchContainer, Collapsible, CreateNewButton, ErrorContainer, FlexHeader, FlexList, ItemBox, Label, Link, MaxHeightContainer, MaxWidth, MobileMenu, MobileModal, Navbar, SongLink } from "~/components";
@@ -17,10 +17,11 @@ import { RoleEnum } from "~/utils/enums";
 export async function loader({ request, params }: LoaderArgs) {
   await requireUserId(request)
 
-  const setlistId = params.setlistId
+  const { setlistId, bandId } = params
   invariant(setlistId, 'setlistId not found')
+  invariant(bandId, 'bandId not found')
 
-  const setlist = await getSetlist(setlistId)
+  const [setlist] = await Promise.all([getSetlist(setlistId), deleteUnneededClonedSetlists(bandId)])
 
   if (!setlist) {
     throw new Response("Setlist not found", { status: 404 })

--- a/app/routes/$bandId/songs.tsx
+++ b/app/routes/$bandId/songs.tsx
@@ -11,6 +11,7 @@ import { RoleEnum } from "~/utils/enums";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { sortByLabel } from "~/utils/params";
 import { useState } from "react";
+import { deleteUnneededClonedSetlists } from "~/models/setlist.server";
 
 export const meta: MetaFunction = () => ({
   title: "Songs",
@@ -39,7 +40,7 @@ export async function loader({ request, params }: LoaderArgs) {
     positions: positionParams,
   }
 
-  const songs = await getSongs(bandId, songParams)
+  const [songs] = await Promise.all([getSongs(bandId, songParams), deleteUnneededClonedSetlists(bandId)])
 
   return json({ songs })
 }


### PR DESCRIPTION
I would prefer this to be done by prompting the user when they try to navigate away from the `edit` route. But that seems to not be an option currently. Should return to this when an obvious path forward presents itself.